### PR TITLE
Fix TestExtensionAPIServerConfigMap

### DIFF
--- a/pkg/cmd/server/kubernetes/master/master_config.go
+++ b/pkg/cmd/server/kubernetes/master/master_config.go
@@ -703,26 +703,3 @@ func getAPIResourceConfig(options configapi.MasterConfig) apiserverstorage.APIRe
 	return resourceConfig
 }
 
-// TODO remove this func in 1.6 when we get rid of the hack above
-func concatenateFiles(prefix, separator string, files ...string) (string, error) {
-	data := []byte{}
-	for _, file := range files {
-		fileBytes, err := ioutil.ReadFile(file)
-		if err != nil {
-			return "", err
-		}
-		data = append(data, fileBytes...)
-		data = append(data, []byte(separator)...)
-	}
-	tmpFile, err := ioutil.TempFile("", prefix)
-	if err != nil {
-		return "", err
-	}
-	if _, err := tmpFile.Write(data); err != nil {
-		return "", err
-	}
-	if err := tmpFile.Close(); err != nil {
-		return "", err
-	}
-	return tmpFile.Name(), nil
-}

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -40,7 +39,6 @@ import (
 	v1beta1extensions "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 	kclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
-	"k8s.io/kubernetes/pkg/master"
 
 	authzapiv1 "github.com/openshift/origin/pkg/authorization/api/v1"
 	authzcache "github.com/openshift/origin/pkg/authorization/authorizer/cache"
@@ -181,13 +179,6 @@ func (c *MasterConfig) Run(kc *kubernetes.MasterConfig, assetConfig *AssetConfig
 	if err != nil {
 		glog.Fatalf("Failed to launch master: %v", err)
 	}
-	clientCARegistrationHook, err := c.ClientCARegistrationHook()
-	if err != nil {
-		glog.Fatalf("Failed to launch master: %v", err)
-	}
-	if kmaster.GenericAPIServer.AddPostStartHook("ca-registration", clientCARegistrationHook.PostStartHook); err != nil {
-		glog.Fatalf("Error registering PostStartHook %q: %v", "ca-registration", err)
-	}
 
 	c.InstallProtectedAPI(kmaster.GenericAPIServer)
 	messages = append(messages, c.kubernetesAPIMessages(kc)...)
@@ -199,36 +190,6 @@ func (c *MasterConfig) Run(kc *kubernetes.MasterConfig, assetConfig *AssetConfig
 
 	// Attempt to verify the server came up for 20 seconds (100 tries * 100ms, 100ms timeout per try)
 	cmdutil.WaitForSuccessfulDial(c.TLS, c.Options.ServingInfo.BindNetwork, c.Options.ServingInfo.BindAddress, 100*time.Millisecond, 100*time.Millisecond, 100)
-}
-
-func (c *MasterConfig) ClientCARegistrationHook() (*master.ClientCARegistrationHook, error) {
-	clientCA, err := readCAorNil(c.Options.ServingInfo.ClientCA)
-	if err != nil {
-		return nil, err
-	}
-	ret := &master.ClientCARegistrationHook{ClientCA: clientCA}
-
-	var requestHeaderProxyCA []byte
-	if c.Options.AuthConfig.RequestHeader != nil {
-		requestHeaderProxyCA, err = readCAorNil(c.Options.AuthConfig.RequestHeader.ClientCA)
-		if err != nil {
-			return nil, err
-		}
-		ret.RequestHeaderUsernameHeaders = c.Options.AuthConfig.RequestHeader.UsernameHeaders
-		ret.RequestHeaderGroupHeaders = c.Options.AuthConfig.RequestHeader.GroupHeaders
-		ret.RequestHeaderExtraHeaderPrefixes = c.Options.AuthConfig.RequestHeader.ExtraHeaderPrefixes
-		ret.RequestHeaderCA = requestHeaderProxyCA
-		ret.RequestHeaderAllowedNames = c.Options.AuthConfig.RequestHeader.ClientCommonNames
-	}
-
-	return ret, nil
-}
-
-func readCAorNil(file string) ([]byte, error) {
-	if len(file) == 0 {
-		return nil, nil
-	}
-	return ioutil.ReadFile(file)
 }
 
 type sortedGroupVersions []schema.GroupVersion


### PR DESCRIPTION
Upstream has its own `ClientCARegistrationHook` in the master config and was overriding our `ca-registration` post start hook, with an empty `ClientCA`. So the ConfigMap in the test was not existing.