### PR TITLE
Populate Service IP Range

### DIFF
--- a/pkg/cmd/server/kubernetes/master/master_config.go
+++ b/pkg/cmd/server/kubernetes/master/master_config.go
@@ -459,6 +459,7 @@ func buildKubeApiserverConfig(
 		APIServerServicePort:      443,
 		ServiceNodePortRange:      apiserverOptions.ServiceNodePortRange,
 		KubernetesServiceNodePort: apiserverOptions.KubernetesServiceNodePort,
+		ServiceIPRange:            apiserverOptions.ServiceClusterIPRange,
 
 		StorageFactory:          storageFactory,
 		APIResourceConfigSource: getAPIResourceConfig(masterConfig),


### PR DESCRIPTION
In order for Kubernetes to actually correctly create the "kubernetes"
service, the `ServiceIPRange` config option has to be populated in
the Kubernetes master config.