### PR TITLE
Build instead of Status in build webhook

### DIFF
--- a/pkg/util/rest/webhook.go
+++ b/pkg/util/rest/webhook.go
@@ -3,11 +3,12 @@ package rest
 import (
 	"net/http"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/api"
+
+	buildapi "github.com/openshift/origin/pkg/build/api"
 )
 
 // HookHandler is a Kubernetes API compatible webhook that is able to get access to the raw request
@@ -54,7 +55,7 @@ func NewHTTPWebHook(handler http.Handler, allowGet bool) *WebHook {
 
 // New() responds with the status object.
 func (h *WebHook) New() runtime.Object {
-	return &metav1.Status{}
+	return &buildapi.Build{}
 }
 
 // Connect responds to connections with a ConnectHandler

--- a/test/integration/etcd_storage_path_test.go
+++ b/test/integration/etcd_storage_path_test.go
@@ -696,10 +696,6 @@ var ephemeralWhiteList = createEphemeralWhiteList(
 	gvr("federation", "v1beta1", "clusters"), // we cannot create this  // TODO but we should be able to create it in kube
 	// --
 
-	// k8s.io/kubernetes/pkg/api/unversioned
-	gvr("", "v1", "statuses"), // return value for calls, not stored in etcd
-	// --
-
 	// k8s.io/kubernetes/pkg/api/v1
 	gvr("", "v1", "bindings"),             // annotation on pod, not stored in etcd
 	gvr("", "v1", "rangeallocations"),     // stored in various places in etcd but cannot be directly created // TODO maybe possible in kube
@@ -766,6 +762,7 @@ var kindWhiteList = sets.NewString(
 	// k8s.io/apimachinery/pkg/apis/meta/v1
 	"APIVersions",
 	"APIGroup",
+	"Status",
 
 	// k8s.io/kubernetes/pkg/api/v1
 	"DeleteOptions",

--- a/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/vendor/k8s.io/kubernetes/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -139,7 +139,7 @@ func (a *APIInstaller) getResourceKind(path string, storage rest.Storage) (schem
 	}
 
 	object := storage.New()
-	fqKinds, unversioned, err := a.group.Typer.ObjectKinds(object)
+	fqKinds, _, err := a.group.Typer.ObjectKinds(object)
 	if err != nil {
 		return schema.GroupVersionKind{}, err
 	}
@@ -147,11 +147,7 @@ func (a *APIInstaller) getResourceKind(path string, storage rest.Storage) (schem
 	// a given go type can have multiple potential fully qualified kinds.  Find the one that corresponds with the group
 	// we're trying to register here
 	fqKindToRegister := schema.GroupVersionKind{}
-	unversionedCandidate := schema.GroupVersionKind{}
 	for _, fqKind := range fqKinds {
-		if unversioned && fqKind.Group == "" {
-			unversionedCandidate = fqKind
-		}
 		if fqKind.Group == a.group.GroupVersion.Group {
 			fqKindToRegister = a.group.GroupVersion.WithKind(fqKind.Kind)
 			break
@@ -162,11 +158,6 @@ func (a *APIInstaller) getResourceKind(path string, storage rest.Storage) (schem
 		if fqKind.Group == "extensions" && fqKind.Kind == "ThirdPartyResourceData" {
 			fqKindToRegister = a.group.GroupVersion.WithKind(fqKind.Kind)
 		}
-	}
-
-	// if we find an unversioned kind in the core group (like Status), accept that.
-	if fqKindToRegister.Empty() && !unversionedCandidate.Empty() {
-		return unversionedCandidate, nil
 	}
 	if fqKindToRegister.Empty() {
 		return schema.GroupVersionKind{}, fmt.Errorf("unable to locate fully qualified kind for %v: found %v when registering for %v", reflect.TypeOf(object), fqKinds, a.group.GroupVersion)


### PR DESCRIPTION
This gets rid of the Status type as `New()` value for the build webhook storage.