### PR TITLE
fix: be fatal on DNS informer error and fix init order

### DIFF
--- a/pkg/cmd/server/kubernetes/node/node_config.go
+++ b/pkg/cmd/server/kubernetes/node/node_config.go
@@ -335,7 +335,10 @@ func BuildKubernetesNodeConfig(options configapi.NodeConfig, enableProxy, enable
 			dnsConfig.Nameservers = options.DNSNameservers
 		}
 
-		services := dns.NewCachedServiceAccessor(internalKubeInformers.Core().InternalVersion().Services())
+		services, err := dns.NewCachedServiceAccessor(internalKubeInformers.Core().InternalVersion().Services())
+		if err != nil {
+			return nil, fmt.Errorf("could not start DNS: failed to add ClusterIP index: %v", err)
+		}
 
 		// TODO: use kubeletConfig.ResolverConfig as an argument to etcd in the event the
 		//   user sets it, instead of passing it to the kubelet.

--- a/pkg/cmd/server/origin/run_components.go
+++ b/pkg/cmd/server/origin/run_components.go
@@ -216,15 +216,19 @@ func (c *MasterConfig) RunDNSServer() {
 		return
 	}
 
+	services, err := dns.NewCachedServiceAccessor(c.Informers.InternalKubernetesInformers().Core().InternalVersion().Services())
+	if err != nil {
+		glog.Fatalf("Could not start DNS: failed to add ClusterIP index: %v", err)
+	}
+
 	go func() {
-		services := dns.NewCachedServiceAccessor(c.Informers.InternalKubernetesInformers().Core().InternalVersion().Services())
 		s := dns.NewServer(
 			config,
 			services,
 			c.Informers.InternalKubernetesInformers().Core().InternalVersion().Endpoints().Lister(),
 			"apiserver",
 		)
-		err := s.ListenAndServe()
+		err = s.ListenAndServe()
 		glog.Fatalf("Could not start DNS: %v", err)
 	}()
 

--- a/pkg/cmd/server/start/start_master.go
+++ b/pkg/cmd/server/start/start_master.go
@@ -511,6 +511,11 @@ func StartAPI(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) error {
 
 	oc.Run(kc, embeddedAssetConfig)
 
+	// start DNS before the informers are started because it adds a ClusterIP index.
+	if oc.Options.DNSConfig != nil {
+		oc.RunDNSServer()
+	}
+
 	// start up the informers that we're trying to use in the API server
 	oc.Informers.InternalKubernetesInformers().Start(utilwait.NeverStop)
 	oc.Informers.Start(utilwait.NeverStop)
@@ -518,10 +523,6 @@ func StartAPI(oc *origin.MasterConfig, kc *kubernetes.MasterConfig) error {
 
 	if standaloneAssetConfig != nil {
 		standaloneAssetConfig.Run()
-	}
-
-	if oc.Options.DNSConfig != nil {
-		oc.RunDNSServer()
 	}
 
 	oc.RunProjectAuthorizationCache()

--- a/pkg/dns/serviceaccessor.go
+++ b/pkg/dns/serviceaccessor.go
@@ -32,12 +32,15 @@ var _ ServiceAccessor = &cachedServiceAccessor{}
 
 // NewCachedServiceAccessor returns a service accessor that can answer queries about services.
 // It uses a backing cache to make ClusterIP lookups efficient.
-func NewCachedServiceAccessor(serviceInformer kcoreinformers.ServiceInformer) ServiceAccessor {
-	serviceInformer.Informer().AddIndexers(cache.Indexers{
+func NewCachedServiceAccessor(serviceInformer kcoreinformers.ServiceInformer) (ServiceAccessor, error) {
+	err := serviceInformer.Informer().AddIndexers(cache.Indexers{
 		"clusterIP": indexServiceByClusterIP, // for reverse lookups
 		"namespace": cache.MetaNamespaceIndexFunc,
 	})
-	return &cachedServiceAccessor{store: serviceInformer.Informer().GetIndexer()}
+	if err != nil {
+		return nil, err
+	}
+	return &cachedServiceAccessor{store: serviceInformer.Informer().GetIndexer()}, nil
 }
 
 // ServiceByClusterIP returns the first service that matches the provided clusterIP value.


### PR DESCRIPTION
This fixes the ClusterIP index used for reverse DNS lookups.