### PR TITLE
separate quota evaluation for admission versus reconciliation

### DIFF
--- a/pkg/cmd/server/origin/master_config.go
+++ b/pkg/cmd/server/origin/master_config.go
@@ -245,7 +245,7 @@ func BuildMasterConfig(options configapi.MasterConfig) (*MasterConfig, error) {
 
 	kubeletClientConfig := configapi.GetKubeletClientConfig(options)
 
-	quotaRegistry := quota.NewAllResourceQuotaRegistry(informerFactory, privilegedLoopbackOpenShiftClient, privilegedLoopbackKubeClientsetExternal)
+	quotaRegistry := quota.NewAllResourceQuotaRegistryForAdmission(informerFactory, privilegedLoopbackOpenShiftClient, privilegedLoopbackKubeClientsetExternal)
 	ruleResolver := rulevalidation.NewDefaultRuleResolver(
 		informerFactory.Policies().Lister(),
 		informerFactory.PolicyBindings().Lister(),

--- a/pkg/quota/registry.go
+++ b/pkg/quota/registry.go
@@ -24,6 +24,21 @@ func NewAllResourceQuotaRegistry(informerFactory shared.InformerFactory, osClien
 	return kquota.UnionRegistry{install.NewRegistry(kubeClientSet, informerFactory.KubernetesInformers()), NewOriginQuotaRegistry(informerFactory.ImageStreams(), osClient)}
 }
 
+// NewOriginQuotaRegistryForAdmission returns a registry object that knows how to evaluate quota usage of OpenShift
+// resources.
+// This is different that is used for reconciliation because admission has to check all forms of a resource (legacy and groupified), but
+// reconciliation only has to check one.
+func NewOriginQuotaRegistryForAdmission(isInformer shared.ImageStreamInformer, osClient osclient.Interface) kquota.Registry {
+	return image.NewImageQuotaRegistryForAdmission(isInformer, osClient)
+}
+
+// NewAllResourceQuotaRegistryForAdmission returns a registry object that knows how to evaluate all resources for *admission*.
+// This is different that is used for reconciliation because admission has to check all forms of a resource (legacy and groupified), but
+// reconciliation only has to check one.
+func NewAllResourceQuotaRegistryForAdmission(informerFactory shared.InformerFactory, osClient osclient.Interface, kubeClientSet clientset.Interface) kquota.Registry {
+	return kquota.UnionRegistry{install.NewRegistry(kubeClientSet, informerFactory.KubernetesInformers()), NewOriginQuotaRegistryForAdmission(informerFactory.ImageStreams(), osClient)}
+}
+
 // AllEvaluatedGroupKinds is the list of all group kinds that we evaluate for quotas in openshift and kube
 var AllEvaluatedGroupKinds = []schema.GroupKind{
 	kapi.Kind("Pod"),


### PR DESCRIPTION
Admission needs to have kinds listed for both legacy and groupified resources.  Reconcilation only needs one.  When it lists both, it doesn't identify them as the same (that mechanism hasn't been built yet) and both evaluators run and are summed.